### PR TITLE
Avoid accessing undefined $media->width

### DIFF
--- a/classes/local/paella_transform.php
+++ b/classes/local/paella_transform.php
@@ -151,8 +151,8 @@ class paella_transform
                 'mimetype' => $media->mediatype,
                 'type' => $media->mediatype,
                 'res' => [
-                    'w' => $media->width,
-                    'h' => $media->height
+                    'w' => isset($media->width) ? $media->width : 0,
+                    'h' => isset($media->height) ? $media->height : 0
                 ]
             ];
         }


### PR DESCRIPTION
When Opencast encodes and publishes audio-only tracks, they won't
have a width or height set causing PHP warnings.

Instead, set h and w to zero if no video exists like Opencast does:
https://github.com/opencast/opencast/blob/develop/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js#L125