### PR TITLE
Update retrieval of preview urls

### DIFF
--- a/classes/local/output_helper.php
+++ b/classes/local/output_helper.php
@@ -221,13 +221,11 @@ class output_helper {
                     foreach ($publication->attachments as $attachment) {
                         if ($attachment->flavor == 'presenter/search+preview') {
                             $presenterpreview = $attachment->url;
-                        }
-                        if ($attachment->flavor == 'presentation/search+preview') {
+                        } else if ($attachment->flavor == 'presentation/search+preview') {
                             $presentationpreview = $attachment->url;
-                        }
-                        if (str_ends_with($attachment->flavor, '/search+preview')) {
+                        } else if (substr($attachment->flavor, -15) === '/search+preview') {
                             $otherpreview = $attachment->url;
-                        }   
+                        }
                     }
                     $url = $presenterpreview ?? $presentationpreview ?? $otherpreview;
 

--- a/classes/local/output_helper.php
+++ b/classes/local/output_helper.php
@@ -227,7 +227,7 @@ class output_helper {
                             $otherpreview = $attachment->url;
                         }
                     }
-                    $url = $presenterpreview ?? $presentationpreview ?? $otherpreview;
+                    $url = $presentationpreview ?? $presenterpreview ?? $otherpreview;
 
                     $video->haspresenter = false;
                     $video->haspresentation = false;

--- a/classes/local/output_helper.php
+++ b/classes/local/output_helper.php
@@ -215,16 +215,22 @@ class output_helper {
             $url = null;
             foreach ($event->publications as $publication) {
                 if ($publication->channel == $channel) {
+                    $presenterpreview = null;
+                    $presentationpreview = null;
+                    $otherpreview = null;
                     foreach ($publication->attachments as $attachment) {
-                        // If presentation preview available, use that, else use presenter preview.
-                        if ($attachment->flavor == 'presentation/search+preview') {
-                            $url = $attachment->url;
-                            break;
-                        }
                         if ($attachment->flavor == 'presenter/search+preview') {
-                            $url = $attachment->url;
+                            $presenterpreview = $attachment->url;
                         }
+                        if ($attachment->flavor == 'presentation/search+preview') {
+                            $presentationpreview = $attachment->url;
+                        }
+                        if (str_ends_with($attachment->flavor, '/search+preview')) {
+                            $otherpreview = $attachment->url;
+                        }   
                     }
+                    $url = $presenterpreview ?? $presentationpreview ?? $otherpreview;
+
                     $video->haspresenter = false;
                     $video->haspresentation = false;
                     foreach ($publication->media as $media) {

--- a/classes/local/paella_transform.php
+++ b/classes/local/paella_transform.php
@@ -68,7 +68,7 @@ class paella_transform {
             }
         }
 
-        return $presenterpreview ?? $presentationpreview ?? $otherpreview;
+        return $presentationpreview ?? $presenterpreview ?? $otherpreview;
     }
 
     /**

--- a/classes/local/paella_transform.php
+++ b/classes/local/paella_transform.php
@@ -68,7 +68,7 @@ class paella_transform {
             }
         }
 
-        return $presentationpreview ?? $presenterpreview ?? $otherpreview;
+        return $presenterpreview ?? $presentationpreview ?? $otherpreview;
     }
 
     /**


### PR DESCRIPTION
This patch changes the retrieval of preview URLs to match the
behavior of the Paella Opencast module (cf. [this code section](https://github.com/opencast/opencast/blob/develop/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js#L525-L535)).