### PR TITLE
Fix bug when time in framelist exists twice

### DIFF
--- a/classes/local/paella_transform.php
+++ b/classes/local/paella_transform.php
@@ -110,9 +110,9 @@ class paella_transform {
                         ];
                     } else {
                         if (substr($attachment->flavor, -5) === 'hires') {
-                            $framelist[$time]->url = $attachment->url;
+                            $framelist[$time]['url'] = $attachment->url;
                         } else {
-                            $framelist[$time]->thumb = $attachment->url;
+                            $framelist[$time]['thumb'] = $attachment->url;
                         }
 
                     }


### PR DESCRIPTION
Previous error: ![image](https://user-images.githubusercontent.com/45795270/196396949-e67e3716-acb9-4436-ae01-a876257b3d6e.png)

Since $framelist[$time] is an array (line 104), it has to be accessed as such