### PR TITLE
New subtitle support

### DIFF
--- a/classes/local/paella_transform.php
+++ b/classes/local/paella_transform.php
@@ -311,9 +311,9 @@ class paella_transform {
             $generator = ucfirst($tagdataarr['generator']);
             $titlearr[] = $generator;
         }
-        if (array_key_exists('generator_type', $tagdataarr)) {
-            $generator_type = $tagdataarr['generator_type'] == 'auto' ? 'A' : 'M';
-            $titlearr[] = "($generator_type)";
+        if (array_key_exists('generatortype', $tagdataarr)) {
+            $generatortype = $tagdataarr['generatortype'] == 'auto' ? 'A' : 'M';
+            $titlearr[] = "($generatortype)";
         }
         if (array_key_exists('type', $tagdataarr)) {
             $type = ucfirst($tagdataarr['type']);

--- a/classes/local/paella_transform.php
+++ b/classes/local/paella_transform.php
@@ -312,7 +312,7 @@ class paella_transform {
             $titlearr[] = $generator;
         }
         if (array_key_exists('generatortype', $tagdataarr)) {
-            $generatortype = $tagdataarr['generatortype'] == 'auto' ? 'A' : 'M';
+            $generatortype = $tagdataarr['generatortype'] === 'auto' ? 'A' : 'M';
             $titlearr[] = "($generatortype)";
         }
         if (array_key_exists('type', $tagdataarr)) {

--- a/classes/local/paella_transform.php
+++ b/classes/local/paella_transform.php
@@ -262,25 +262,25 @@ class paella_transform {
                 if (strpos($type2, 'vtt+') !== false) {
                     list($format, $lang) = explode('+', $type2, 2);
                     $text = $lang;
-                } else if (in_array($type2, ['delivery', 'prepared', 'vtt']) && !empty($media->tags)) { // Opencast 15 coverage.
+                } else if (in_array($type2, ['delivery', 'prepared', 'preview', 'vtt']) && !empty($media->tags)) { // Opencast 15 coverage.
                     $tagdataarr = [];
                     foreach ($media->tags as $tag) {
                         // The safety checker.
                         if (!is_string($tag)) {
                             continue;
                         }
-                        if (strpos($tag, 'lang:') !== false) {
-                            $lang = str_replace('lang:', '', $tag);
+                        if (strpos($tag, 'lang:') === 0) {
+                            $lang = substr($tag, strlen('lang:'));
                             $tagdataarr['lang'] = $lang;
                         }
-                        if (strpos($tag, 'generator-type:') !== false) {
-                            $tagdataarr['generatortype'] = str_replace('generator-type:', '', $tag);
+                        if (strpos($tag, 'generator-type:') === 0) {
+                            $tagdataarr['generatortype'] = substr($tag, strlen('generator-type:'));
                         }
-                        if (strpos($tag, 'generator:') !== false) {
-                            $tagdataarr['generator'] = str_replace('generator:', '', $tag);
+                        if (strpos($tag, 'generator:') === 0) {
+                            $tagdataarr['generator'] = substr($tag, strlen('generator:'));
                         }
-                        if (strpos($tag, 'type:') !== false) {
-                            $tagdataarr['type'] = str_replace('type:', '', $tag);
+                        if (strpos($tag, 'type:') === 0) {
+                            $tagdataarr['type'] = substr($tag, strlen('type:'));
                         }
                     }
                     $text = self::prepare_caption_text($tagdataarr);
@@ -312,14 +312,16 @@ class paella_transform {
             $titlearr[] = $generator;
         }
         if (array_key_exists('generatortype', $tagdataarr)) {
-            $generatortype = $tagdataarr['generatortype'] === 'auto' ? 'A' : 'M';
+            $generatortype = $tagdataarr['generatortype'] === 'auto' ?
+                get_string('captions_generator_type_auto', 'mod_opencast') :
+                get_string('captions_generator_type_manual', 'mod_opencast');
             $titlearr[] = "($generatortype)";
         }
         if (array_key_exists('type', $tagdataarr)) {
             $type = ucfirst($tagdataarr['type']);
             $titlearr[] = "($type)";
         }
-        return implode(' - ', $titlearr);
+        return implode(' ', $titlearr);
     }
 
     /**

--- a/lang/en/opencast.php
+++ b/lang/en/opencast.php
@@ -28,6 +28,9 @@ defined('MOODLE_INTERNAL') || die();
 $string['allvideos'] = 'All videos';
 $string['allowdownload'] = 'Allow students to download the video(s)';
 
+$string['captions_generator_type_auto'] = 'Auto generated';
+$string['captions_generator_type_manual'] = 'Manually generated';
+
 $string['date'] = 'Date';
 $string['downloadvideo'] = 'Download video';
 $string['duration'] = 'Duration';


### PR DESCRIPTION
This PR fixes #48 

### Description
In Opencast 15, captions (subtitles) are provided with different format as for their flavors: captions/delivery ... etc. and every other data including language code etc. is included in the tags.

### Solution
- This patch covers the new subtitles format while it maintain the old ones.
- The get_caption function now cover attachments and media and for media also looks for old and new subtitles.

### To TEST
- You would need to have Opencast 15.
- You would need to have auto generated captions as well as manually uploaded caption via block_opencast plugin (or any other way) in order to test all cases.
- Try to watch the event via this plugin or in filter plugin
- All captions must be accessible in the paella player!