### PR TITLE
Improve error handleing and messaging + opencast api integration

### DIFF
--- a/classes/local/output_helper.php
+++ b/classes/local/output_helper.php
@@ -56,7 +56,7 @@ class output_helper {
         $response = $api->get_episodes_in_series($seriesid, $sortseriesby);
 
         if ($response === false) {
-            throw new \exception('There was a problem reaching opencast!');
+            throw new \moodle_exception('opencastnotreachable', 'mod_opencast');
         }
 
         $context = self::create_template_context_for_series($ocinstanceid, $response);
@@ -102,11 +102,11 @@ class output_helper {
     public static function output_episode($ocinstanceid, $episodeid, $modinstanceid, $seriesid = null): void {
         global $PAGE, $OUTPUT, $DB;
 
-        $data = paella_transform::get_paella_data_json($ocinstanceid, $episodeid, $seriesid);
+        list($data, $errormessage) = paella_transform::get_paella_data_json($ocinstanceid, $episodeid, $seriesid);
 
-        if (!$data) {
+        if (empty($data)) {
             echo $OUTPUT->header();
-            echo $OUTPUT->heading(get_string('errorfetchingvideo', 'mod_opencast'));
+            echo $OUTPUT->heading($errormessage);
             echo $OUTPUT->footer();
             return;
         }

--- a/lang/en/opencast.php
+++ b/lang/en/opencast.php
@@ -45,7 +45,8 @@ $string['duration'] = 'Duration';
 $string['episode'] = 'Opencast episode';
 $string['erroremptystreamsources'] = 'There is no video source available. Please contact your system administrator.';
 $string['errorfetchingvideo'] = 'There was a problem fetching the video.';
-
+$string['errorvideonotavailable'] = 'Unable to find the video! <br />Please contact your system administrator.';
+$string['errorvideonotready'] = 'The video is either not ready yet or cannot be properly accessed from the source!<br />Please try again later.';
 $string['gridview'] = 'View as grid';
 
 $string['listview'] = 'View as list';
@@ -60,6 +61,7 @@ $string['opencast:addinstance'] = 'Add a new Video (Opencast) instance';
 $string['opencastid'] = 'Opencast ID';
 $string['opencastidnotrecognized'] = 'This ID is neither recognized as a series nor a video.';
 $string['opencastname'] = 'Opencast Video Provider: {$a}';
+$string['opencastnotreachable'] = 'Opencast is currently not reachable, please try again later.';
 
 $string['pluginadministration'] = 'Opencast Video Provider administration';
 $string['pluginname'] = 'Opencast Video Provider';


### PR DESCRIPTION
This PR fixes #26 

### Description
The error message shown when opening a video/series is very blur and it is not descriptive.
Also I have found out that this plugin still uses the old api calls which have been depricate long time ago.

### Solution
- **The Opencast API (PHP Library) is now being used/integrated.**
- The Error messages shown now got a bit more meaningful details, so that the user knows more about what is happening if there is an error in two following cases:
  - If the opencast is down or not accessible
  - If the publication to extract video url is not ready or the configuration is incorrect.
We don't need more to describe to users apart from these 2 cases, as this plugin play the role of presenting the video to the end-users.

### TO TEST
- Patch this PR
- Make sure you have a course with at least an upload video via block plugin! 
- As we introduced the Opencast API integration, it is very helpful to test this PR throughly! means all functions as follows:
  - Check if the existing video in mod plugin still work/ behave as expected!
  - Try to create a new video with mod plugin.
  - Try to create a new series with mod plugin
- To see the newly added error messages:
   - temporary change the opencast credentials in tool plugin and then try to open an existing video in mod plugin
   - Run a long workflow process on an uploaded video and try to access/create mod video out of that during the process and check the error message!