### PR TITLE
Migrate Settings from block_opencast to tool_opencast

### DIFF
--- a/.github/workflows/moodle-release.yml
+++ b/.github/workflows/moodle-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call-moodle-release-workflow:
-    uses: Opencast-Moodle/moodle-workflows-opencast/.github/workflows/moodle-release.yml@master
+    uses: Opencast-Moodle/moodle-workflows-opencast/.github/workflows/moodle-release.yml@main
     with:
       plugin-name: 'mod_opencast'
     secrets: inherit

--- a/downloadvideo.php
+++ b/downloadvideo.php
@@ -22,7 +22,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use block_opencast\local\apibridge;
+use tool_opencast\local\apibridge;
 require_once('../../config.php');
 
 global $PAGE, $OUTPUT, $CFG, $DB;

--- a/lib.php
+++ b/lib.php
@@ -144,7 +144,7 @@ function mod_opencast_get_fontawesome_icon_map() {
 function opencast_dndupload_register() {
     // Getting default opencast instance.
     $defaultocinstanceid = \tool_opencast\local\settings_api::get_default_ocinstance()->id;
-    // Getting file extensions from the block_opencast configuration using default ocinstanceid.
+    // Getting file extensions from the tool_opencast configuration using default ocinstanceid.
     $videotypescfg = get_config('tool_opencast', 'uploadfileextensions_' . $defaultocinstanceid);
     $videoexts = empty($videotypescfg) || $videotypescfg == 'video' ?
         file_get_typegroup('extension', 'video') :

--- a/lib.php
+++ b/lib.php
@@ -145,7 +145,7 @@ function opencast_dndupload_register() {
     // Getting default opencast instance.
     $defaultocinstanceid = \tool_opencast\local\settings_api::get_default_ocinstance()->id;
     // Getting file extensions from the block_opencast configuration using default ocinstanceid.
-    $videotypescfg = get_config('block_opencast', 'uploadfileextensions_' . $defaultocinstanceid);
+    $videotypescfg = get_config('tool_opencast', 'uploadfileextensions_' . $defaultocinstanceid);
     $videoexts = empty($videotypescfg) || $videotypescfg == 'video' ?
         file_get_typegroup('extension', 'video') :
         array_map('trim', explode(',', $videotypescfg));

--- a/uploadvideo.php
+++ b/uploadvideo.php
@@ -28,9 +28,9 @@ require_once($CFG->dirroot . '/course/modlib.php');
 require_once($CFG->libdir . '/gradelib.php');
 require_once(__DIR__ . '/uploadvideo_form.php');
 
-use block_opencast\local\apibridge;
+use tool_opencast\local\apibridge;
 use tool_opencast\local\settings_api;
-use block_opencast\local\upload_helper;
+use tool_opencast\local\upload_helper;
 
 global $PAGE, $OUTPUT, $USER, $DB;
 
@@ -48,8 +48,8 @@ require_login($course, false, $cm);
 
 $context = context_module::instance($cm->id);
 $coursecontext = context_course::instance($course->id);
-// As we are doing the upload using the block_opencast, we have to use its capability as well.
-require_capability('block/opencast:addvideo', $coursecontext);
+// As we are doing the upload using the tool_opencast, we have to use its capability as well.
+require_capability('tool/opencast:addvideo', $coursecontext);
 
 $PAGE->set_pagelayout('frametop');
 $PAGE->set_context($context);
@@ -62,7 +62,7 @@ if (empty($moduleinstance->uploaddraftitemid)) {
 // Getting all the oc instances.
 $ocinstances = settings_api::get_ocinstances();
 // Getting user defaults.
-$userdefaultsrecord = $DB->get_record('block_opencast_user_default', ['userid' => $USER->id]);
+$userdefaultsrecord = $DB->get_record('tool_opencast_user_default', ['userid' => $USER->id]);
 $userdefaults = $userdefaultsrecord ? json_decode($userdefaultsrecord->defaults, true) : [];
 $usereventdefaults = (!empty($userdefaults['event'])) ? $userdefaults['event'] : [];
 // Getting medatadata catalogs based on the ocinstances.
@@ -128,9 +128,9 @@ if ($mform->is_cancelled()) {
     // Saving and getting the file.
     $newitemid = rand(1000000, 9999999);
     file_save_draft_area_files($moduleinstance->uploaddraftitemid, $coursecontext->id,
-        'block_opencast', upload_helper::OC_FILEAREA, $newitemid);
+        'tool_opencast', upload_helper::OC_FILEAREA, $newitemid);
     $fs = get_file_storage();
-    $files = $fs->get_area_files($coursecontext->id, 'block_opencast', upload_helper::OC_FILEAREA, $newitemid, '', false);
+    $files = $fs->get_area_files($coursecontext->id, 'tool_opencast', upload_helper::OC_FILEAREA, $newitemid, '', false);
     $savedvideofile = null;
     if ($files) {
         $savedvideofile = reset($files);
@@ -142,7 +142,7 @@ if ($mform->is_cancelled()) {
         redirect($redirecturl, get_string('uploadmissingfile', 'mod_opencast'), null, \core\output\notification::NOTIFY_ERROR);
     } else {
         $coursecontext = context_course::instance($course->id);
-        \block_opencast\local\file_deletionmanager::track_draftitemid($coursecontext->id, $savedvideofile->get_itemid());
+        \tool_opencast\local\file_deletionmanager::track_draftitemid($coursecontext->id, $savedvideofile->get_itemid());
     }
 
     $flavorfieldname = 'flavor_' . $ocinstanceid;
@@ -234,10 +234,10 @@ if ($mform->is_cancelled()) {
             \core\notification::warning($e->getMessage());
         }
     }
-    $blockopencastlink = new moodle_url('/blocks/opencast/index.php',
+    $indexopencastlink = new moodle_url('/admin/tool/opencast/index.php',
         ['courseid' => $course->id, 'ocinstanceid' => $ocinstanceid]);
     redirect($redirecturl,
-        get_string('uploadsaved', 'mod_opencast', $blockopencastlink->out()), null, \core\output\notification::NOTIFY_SUCCESS);
+        get_string('uploadsaved', 'mod_opencast', $indexopencastlink->out()), null, \core\output\notification::NOTIFY_SUCCESS);
 }
 
 $PAGE->set_title(get_string('uploadformtitle', 'mod_opencast'));

--- a/uploadvideo_form.php
+++ b/uploadvideo_form.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die;
 
 require_once($CFG->libdir . '/formslib.php');
 
-use block_opencast\local\autocomplete_suggestion_helper;
+use tool_opencast\local\autocomplete_suggestion_helper;
 
 /**
  * Video Upload form
@@ -45,7 +45,7 @@ class mod_opencast_uploadvideo_form extends moodleform {
     public function definition() {
         global $PAGE, $OUTPUT;
         // Get the renderer to use its methods.
-        $renderer = $PAGE->get_renderer('block_opencast');
+        $renderer = $PAGE->get_renderer('tool_opencast');
 
         $cmid = $this->_customdata['cmid'];
         $ocinstances = $this->_customdata['ocinstances'];
@@ -123,11 +123,11 @@ class mod_opencast_uploadvideo_form extends moodleform {
                 if ($field->datatype == 'autocomplete') {
                     $attributes = [
                         'multiple' => true,
-                        'placeholder' => get_string('metadata_autocomplete_placeholder', 'block_opencast',
-                            $this->try_get_string($field->name, 'block_opencast')),
+                        'placeholder' => get_string('metadata_autocomplete_placeholder', 'tool_opencast',
+                            $this->try_get_string($field->name, 'tool_opencast')),
                         'showsuggestions' => true,
-                        'noselectionstring' => get_string('metadata_autocomplete_noselectionstring', 'block_opencast',
-                            $this->try_get_string($field->name, 'block_opencast')),
+                        'noselectionstring' => get_string('metadata_autocomplete_noselectionstring', 'tool_opencast',
+                            $this->try_get_string($field->name, 'tool_opencast')),
                         'tags' => true,
                     ];
 
@@ -145,14 +145,14 @@ class mod_opencast_uploadvideo_form extends moodleform {
                 }
 
                 // Get the created element back from addElement function, in order to further use its attrs.
-                $lbltext = $this->try_get_string($field->name, 'block_opencast');
+                $lbltext = $this->try_get_string($field->name, 'tool_opencast');
                 $element = $mform->addElement($field->datatype, $elementid, $lbltext, $param, $attributes);
 
                 // Check if the description is set for the field, to display it as help icon.
                 if (isset($field->description) && !empty($field->description)) {
                     // Use the renderer to generate a help icon with custom text.
                     $element->_helpbutton = $renderer->render_help_icon_with_custom_text(
-                        $this->try_get_string($field->name, 'block_opencast'), $field->description);
+                        $this->try_get_string($field->name, 'tool_opencast'), $field->description);
                 }
 
                 if ($field->datatype == 'text') {
@@ -169,7 +169,7 @@ class mod_opencast_uploadvideo_form extends moodleform {
             }
             if ($settitle) {
                 $elementid = 'title_' . $ocinstance->id;
-                $mform->addElement('text', 'title_' . $elementid, get_string('title', 'block_opencast'));
+                $mform->addElement('text', 'title_' . $elementid, get_string('title', 'tool_opencast'));
                 $mform->setType($elementid, PARAM_TEXT);
                 $mform->disabledIf($elementid, 'ocinstance' , 'neq', $ocinstance->id);
                 $mform->hideif($elementid, 'ocinstance' , 'neq', $ocinstance->id);
@@ -201,7 +201,7 @@ class mod_opencast_uploadvideo_form extends moodleform {
         $mform->setType('metadatacatalogs', PARAM_TEXT);
 
         $mform->closeHeaderBefore('buttonar');
-        $this->add_action_buttons(true, get_string('addvideo', 'block_opencast'));
+        $this->add_action_buttons(true, get_string('addvideo', 'tool_opencast'));
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -27,10 +27,10 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_opencast';
 $plugin->release = 'v4.5-r4';
-$plugin->version = 2024111103;
+$plugin->version = 2025042200;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->supported = [405, 405];
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [
-    'tool_opencast' => 2024111103,
+    'tool_opencast' => 2025042200,
 ];

--- a/view.php
+++ b/view.php
@@ -104,9 +104,9 @@ if ($moduleinstance->type == opencasttype::EPISODE) {
     $messagetext = get_string('uploadlandinginfo', 'mod_opencast');
     $messagestatus = \core\output\notification::NOTIFY_INFO;
     $url = new moodle_url('/mod/opencast/uploadvideo.php', ['cmid' => $cm->id]);
-    // Check the addvideo capability from block_opencast.
+    // Check the addvideo capability from tool_opencast.
     $coursecontext = context_course::instance($course->id);
-    if (!has_capability('block/opencast:addvideo', $coursecontext)) {
+    if (!has_capability('tool/opencast:addvideo', $coursecontext)) {
         // If capability is not met, redirect back with message.
         $url = new moodle_url('/course/view.php', ['id' => $course->id]);
         $messagetext = get_string('uploadnotallowed', 'mod_opencast');
@@ -125,7 +125,7 @@ if ($moduleinstance->type == opencasttype::EPISODE) {
     redirect($url, $messagetext, null, $messagestatus);
 } else if ($moduleinstance->type == opencasttype::UPLOADED) {
     $url = new moodle_url('/course/view.php', ['id' => $course->id]);
-    $uploadjob = $DB->get_record('block_opencast_uploadjob', ['id' => $moduleinstance->uploadjobid]);
+    $uploadjob = $DB->get_record('tool_opencast_uploadjob', ['id' => $moduleinstance->uploadjobid]);
     if (empty($uploadjob) || empty($uploadjob->opencasteventid)) {
         $messagetext = get_string('uploadinprogress', 'mod_opencast', $moduleinstance->name);
         $messagestatus = \core\output\notification::NOTIFY_INFO;
@@ -139,7 +139,7 @@ if ($moduleinstance->type == opencasttype::EPISODE) {
         redirect($url, $messagetext, null, $messagestatus);
     }
     $opencasteventid = $uploadjob->opencasteventid;
-    $apibridge = \block_opencast\local\apibridge::get_instance($moduleinstance->ocinstanceid);
+    $apibridge = \tool_opencast\local\apibridge::get_instance($moduleinstance->ocinstanceid);
     $video = $apibridge->get_opencast_video($opencasteventid);
     if ($video->video->processing_state != 'SUCCEEDED') {
         $messagetext = get_string('uploadedvideoisbeingprocesses', 'mod_opencast', $moduleinstance->name);


### PR DESCRIPTION
This PR adapts mod_opencast to the migration of the settings from block_opencast to tool_opencast in order to make the block_opencast Plugin optional.
This PR is intended as a draft for the community to review and provide feedback on the proposed changes.

PR drafts are available in tool_opencast, block_opencast, filter_opencast, mod_opencast