### PR TITLE
Fix episode sorting

### DIFF
--- a/classes/local/apibridge.php
+++ b/classes/local/apibridge.php
@@ -86,13 +86,11 @@ class apibridge {
 
         $sort = [
             'start_date' => 'DESC',
-            'title' => 'ASC',
         ];
 
         if ($sortseriesby == 1) {
             $sort = [
                 'title' => 'ASC',
-                'start_date' => 'DESC',
             ];
         }
 


### PR DESCRIPTION
Sorting by both columns results in an unexpected behavior. The sort  order does not correspond to the configured value and seems kind of  random. 