### PR TITLE
Replace global download configuration with enforce download default policy

### DIFF
--- a/classes/local/output_helper.php
+++ b/classes/local/output_helper.php
@@ -153,10 +153,12 @@ class output_helper {
                 [$configurl->out(false), $themeurl->out(false)]);
 
         $moduleinstance = $DB->get_record('opencast', ['id' => $modinstanceid], '*', MUST_EXIST);
-        if (get_config('mod_opencast', 'global_download_' . $ocinstanceid) || $moduleinstance->allowdownload) {
+
+        $enforce = get_config('mod_opencast', 'enforce_download_default_' . $ocinstanceid);
+        $allowdownload = get_config('mod_opencast', 'download_default_' . $ocinstanceid);
+        if (($enforce && $allowdownload) || (!$enforce && $moduleinstance->allowdownload)) {
             self::output_download_menu($ocinstanceid, $episodeid, $modinstanceid);
         }
-
         echo $OUTPUT->footer();
     }
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -137,5 +137,19 @@ function xmldb_opencast_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2023100900, 'opencast');
     }
 
+    if ($oldversion < 2025080100.01) {
+        $configs = $DB->get_records_select(
+                'config_plugins',
+                "plugin = :plugin AND name LIKE :pattern",
+                ['plugin' => 'mod_opencast', 'pattern' => 'global_download_%']
+        );
+        foreach ($configs as $config) {
+            $DB->delete_records('config_plugins', ['id' => $config->id]);
+        }
+
+        // Opencast savepoint reached.
+        upgrade_mod_savepoint(true, 2025080100.01, 'opencast');
+    }
+
     return true;
 }

--- a/downloadvideo.php
+++ b/downloadvideo.php
@@ -56,44 +56,45 @@ if (empty($cm->visible) && !has_capability('moodle/course:viewhiddenactivities',
 
 $apibridge = apibridge::get_instance($ocinstanceid);
 $result = $apibridge->get_opencast_video($episode, true);
-if (!$result->error) {
-    $video = $result->video;
-    foreach ($video->publications as $publication) {
-        if ($publication->channel == get_config('mod_opencast', 'download_channel_' . $ocinstanceid)) {
-            foreach ($publication->media as $media) {
-                if ($media->id === $mediaid) {
-                    $downloadurl = $media->url;
-                    $mimetype = $media->mediatype;
-                    $size = $media->size;
-                    break 2;
-                }
+
+if ($result->error) {
+    throw new moodle_exception('errorgettingvideo', 'mod_opencast', '', $result->error);
+}
+
+$video = $result->video;
+foreach ($video->publications as $publication) {
+    if ($publication->channel === get_config('mod_opencast', 'download_channel_' . $ocinstanceid)) {
+        foreach ($publication->media as $media) {
+            if ($media->id === $mediaid) {
+                $downloadurl = $media->url;
+                $mimetype = $media->mediatype;
+                $size = $media->size;
+                break 2;
             }
         }
     }
-    if (!$downloadurl) {
-        throw new coding_exception('Publication could not be found!');
-    }
-
-    $filename = $video->title . '.' . pathinfo($downloadurl, PATHINFO_EXTENSION);
-
-    header('Content-Description: Download Video');
-    header('Content-Type: ' . $mimetype);
-    header('Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($filename));
-    if (is_numeric($size) && $size > 0) {
-        header('Content-Length: ' . $size);
-    }
-
-    if (is_https()) { // HTTPS sites - watch out for IE! KB812935 and KB316431.
-        header('Cache-Control: private, max-age=10, no-transform');
-        header('Expires: ' . gmdate('D, d M Y H:i:s', 0) . ' GMT');
-        header('Pragma: ');
-    } else { // Normal http - prevent caching at all cost.
-        header('Cache-Control: private, must-revalidate, pre-check=0, post-check=0, max-age=0, no-transform');
-        header('Expires: ' . gmdate('D, d M Y H:i:s', 0) . ' GMT');
-        header('Pragma: no-cache');
-    }
-
-    readfile($downloadurl);
-} else {
-    die();
 }
+if (!$downloadurl) {
+    throw new coding_exception('Publication could not be found!');
+}
+
+$filename = $video->title . '.' . pathinfo($downloadurl, PATHINFO_EXTENSION);
+
+header('Content-Description: Download Video');
+header('Content-Type: ' . $mimetype);
+header('Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($filename));
+if (is_numeric($size) && $size > 0) {
+    header('Content-Length: ' . $size);
+}
+
+if (is_https()) { // HTTPS sites - watch out for IE! KB812935 and KB316431.
+    header('Cache-Control: private, max-age=10, no-transform');
+    header('Expires: ' . gmdate('D, d M Y H:i:s', 0) . ' GMT');
+    header('Pragma: ');
+} else { // Normal http - prevent caching at all cost.
+    header('Cache-Control: private, must-revalidate, pre-check=0, post-check=0, max-age=0, no-transform');
+    header('Expires: ' . gmdate('D, d M Y H:i:s', 0) . ' GMT');
+    header('Pragma: no-cache');
+}
+
+readfile($downloadurl);

--- a/downloadvideo.php
+++ b/downloadvideo.php
@@ -41,14 +41,17 @@ $cm = get_coursemodule_from_instance('opencast', $moduleinstance->id, $course->i
 require_login($course, true, $cm);
 $modulecontext = context_module::instance($cm->id);
 
+$enforce = get_config('mod_opencast', 'enforce_download_default_' . $ocinstanceid);
+$allowdownload = get_config('mod_opencast', 'download_default_' . $ocinstanceid);
+
 // Check if teacher enabled download.
-if (!get_config('mod_opencast', 'global_download_' . $ocinstanceid) && !$moduleinstance->allowdownload) {
-    die();
+if (($enforce && !$allowdownload) || (!$enforce && !$moduleinstance->allowdownload)) {
+    throw new moodle_exception('nopermissiontodownload', 'mod_opencast');
 }
 
 // Check if activity is visible for student.
 if (empty($cm->visible) && !has_capability('moodle/course:viewhiddenactivities', $modulecontext)) {
-    die();
+    throw new moodle_exception('nopermissiontodownload', 'mod_opencast');
 }
 
 $apibridge = apibridge::get_instance($ocinstanceid);

--- a/lang/en/opencast.php
+++ b/lang/en/opencast.php
@@ -72,13 +72,13 @@ $string['seriesisempty'] = 'This series is currently empty.';
 $string['settings:api-channel'] = 'Opencast Channel';
 $string['settings:configurl'] = 'URL to Paella config.json';
 $string['settings:configurl_desc'] = 'URL of the config.json used by Paella Player. Can either be a absolute URL or a URL relative to the wwwroot.';
+$string['settings:enforce_download_default'] = 'Enforce download default';
+$string['settings:enforce_download_default_desc'] = 'Enforce the default download setting globally. Teachers cannot overwrite this setting.';
 $string['settings:download-channel'] = 'Opencast Download Channel';
 $string['settings:download-channel_desc'] = 'Opencast publication channel from which the videos are served when downloading them.';
 $string['settings:download-default'] = 'Allow download by default';
 $string['settings:download-default_desc'] = 'If activated, the checkbox for allowing downloads in activity forms is checked by default.';
 $string['settings:download_header'] = 'Student Download Configuration';
-$string['settings:global_download'] = 'Force student download';
-$string['settings:global_download_desc'] = 'Allow globally that students can download videos. Teachers cannot overwrite this setting.';
 $string['settings:themeurl'] = 'URL to Paella theme.json';
 $string['settings:themeurl_desc'] = 'URL of the theme.json used by Paella Player. Can either be a absolute URL or a URL relative to the wwwroot.';
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -114,15 +114,13 @@ class mod_opencast_mod_form extends moodleform_mod {
             $mform->addRule('opencastid', get_string('required'), 'required');
             $mform->hideIf('opencastid', 'manualocid', 'eq', '0');
 
-            if (get_config('mod_opencast', 'global_download_' . $ocinstanceid)) {
+            if (get_config('mod_opencast', 'enforce_download_default_' . $ocinstanceid)) {
                 $mform->addElement('hidden', 'allowdownload');
-                $mform->setType('allowdownload', PARAM_INT);
-                $mform->setDefault('allowdownload', '1');
             } else {
                 $mform->addElement('advcheckbox', 'allowdownload', get_string('allowdownload', 'mod_opencast'));
-                $mform->setType('allowdownload', PARAM_INT);
-                $mform->setDefault('allowdownload', get_config('mod_opencast', 'download_default_' . $ocinstanceid));
             }
+            $mform->setType('allowdownload', PARAM_INT);
+            $mform->setDefault('allowdownload', get_config('mod_opencast', 'download_default_' . $ocinstanceid));
 
             $mform->addElement('header', 'advancedsettings', get_string('advancedsettings', 'mod_opencast'));
 

--- a/settings.php
+++ b/settings.php
@@ -60,8 +60,8 @@ if ($hassiteconfig) {
             new lang_string('settings:download-default', 'mod_opencast'),
             new lang_string('settings:download-default_desc', 'mod_opencast'), 0));
 
-        $settings->add(new admin_setting_configcheckbox('mod_opencast/global_download_' . $ocinstance->id,
-            new lang_string('settings:global_download', 'mod_opencast'),
-            new lang_string('settings:global_download_desc', 'mod_opencast'), 0));
+        $settings->add(new admin_setting_configcheckbox('mod_opencast/enforce_download_default_' . $ocinstance->id,
+                new lang_string('settings:enforce_download_default', 'mod_opencast'),
+                new lang_string('settings:enforce_download_default_desc', 'mod_opencast'), 0));
     }
 }

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_opencast';
 $plugin->release = 'v5.0-r1';
-$plugin->version = 2025080100;
+$plugin->version = 2025080100.01;
 $plugin->requires = 2025041400; // Requires Moodle 5.0+.
 $plugin->supported = [500, 500];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
The new `enforce_download_default` setting not only allows enforcing
downloads globally, but also allows for the disabling of downloads by
enforcing the default policy instead of overwriting it.

This enables more flexible and targeted control over download behavior.

<img width="860" height="294" alt="grafik" src="https://github.com/user-attachments/assets/3b324b8e-1eba-4fb0-9a89-379bc850a55d" />
