### PR TITLE
Handle errors gracefully during fresh installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.5.6 (2025-11-07)
+------------------
+[FIXED] Make sure no real api instance is requested and process also during phpunit init
+
+
 4.5.5 (2025-10-24)
 ------------------
 * [FEATURE] Increase opencast coverage in ci

--- a/classes/settings/upload_settings_helper.php
+++ b/classes/settings/upload_settings_helper.php
@@ -249,10 +249,15 @@ class upload_settings_helper {
         self::add_heading($settings, $tabname, $ocinstanceid);
 
         $disabled = false;
-        if (!(defined('BEHAT_UTIL') && BEHAT_UTIL) && !(defined('PHPUNIT_UTIL') && PHPUNIT_UTIL)) {
-            $wfconfighelper = workflowconfiguration_helper::get_instance($ocinstanceid);
-            if (!$wfconfighelper->can_provide_configuration_panel()) {
-                $disabled = true;
+        if (!(defined('BEHAT_UTIL') && BEHAT_UTIL) && !(defined('PHPUNIT_UTIL') && PHPUNIT_UTIL) && !during_initial_install()) {
+            try {
+                $wfconfighelper = workflowconfiguration_helper::get_instance($ocinstanceid);
+                if (!$wfconfighelper->can_provide_configuration_panel()) {
+                    $disabled = true;
+                }
+            } catch (\Throwable $e) {
+                // We want this to NOT throw error at this point, when it does we just disable the feature.
+                $disabled = false;
             }
         }
 

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_opencast';
-$plugin->release = 'v4.5-r6';
-$plugin->version = 2024111105;
+$plugin->release = 'v4.5-r7';
+$plugin->version = 2024111106;
 $plugin->requires = 2024100700; // Requires Moodle 4.5+.
 $plugin->supported = [405, 405];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR fixes #94,
It does just gracefully handle exception in the setting when the tool plugin is not ready yet.

@bluetom please cherry pick the changes to v5.x, thanks.