### PR TITLE
Add block_opencast to dependencies

### DIFF
--- a/version.php
+++ b/version.php
@@ -33,4 +33,5 @@ $plugin->supported = [405, 405];
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [
     'tool_opencast' => 2024111104,
+    'block_opencast' => 2024111100,
 ];


### PR DESCRIPTION
mod_opencast should require block_opencast in MOODLE_405_STABLE since references to block_opencast are used across the plugin.
In later versions this dependencie does not exist anymore.